### PR TITLE
:fix: Handle list of lists returned by subgraphs 

### DIFF
--- a/src/mofdscribe/featurizers/chemistry/_fragment.py
+++ b/src/mofdscribe/featurizers/chemistry/_fragment.py
@@ -67,7 +67,7 @@ def get_node_atoms(structure_graph: StructureGraph) -> Set[int]:
 def get_floating_indices(structure_graph: StructureGraph) -> Set[int]:
     """Get the indices of floating (solvent) molecules in the structure."""
     _, _, idx, _, _ = get_subgraphs_as_molecules(structure_graph)
-    return set(idx)
+    return set(inds for indxs in idx for inds in indxs)
 
 
 def get_bbs_from_indices(structure_graph: StructureGraph, indices: Set[int]):


### PR DESCRIPTION
Also contains changeset from #226.

The `get_subgraphs_as_molecules` function returns a list of lists of indices, which I believe must be expanded to create the a combined set of solvent molecule indices. Initially triggered by the test case in #226, though I can't replicate this in the CI (for some reason I can't even see the logs).