### PR TITLE
Fix "Getting Started" in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ mofdscribe additionally includes routines that help with model validation.
 ```python
 
 from mofdscribe.featurizers.chemistry import RACS
-from pymatgen.core import IStructure
+from pymatgen.core import Structure
 
-structure = IStructure.from_file(<my_cif.cif>)
+structure = Structure.from_file(<my_cif.cif>)
 featurizer = RACS()
 racs_features = featurizer.featurize(structure)
 ```


### PR DESCRIPTION
Two things.

First, the getting started section's import does not seem to be correct. I have changed it from

```python
from mofdscribe.chemistry import RACS
```
to
```python
from mofdscribe.featurizers.chemistry import RACS
```

Second, I have changed the use of `IStructure` in the tutorial to `Structure`. I chose to do this because internally, it is already converted to an `IStructure` when `RACS()` is instantiated, and most of the Pymatgen tutorials (and matminer tutorials) are built around the `Structure` object. Most people are probably more familiar with the `Structure` object, so I figure we should just show that by default.