### PR TITLE
Cosmetic changes to `read_ascii_grid`

### DIFF
--- a/src/mofdscribe/featurizers/chemistry/energygrid.py
+++ b/src/mofdscribe/featurizers/chemistry/energygrid.py
@@ -55,7 +55,7 @@ def read_ascii_grid(filename: Union[str, os.PathLike]) -> pd.DataFrame:
         delim_whitespace=True,
         header=None,
         names=["x", "y", "z", "energy", "deriv_x", "deriv_y", "deriv_z"],
-        na_values='?'
+        na_values="?",
     )
     df = df.astype(np.float)
     return df


### PR DESCRIPTION
- Replaces the `sep` kwarg with `delim_whitespace`. Functionally, it's the same, but it's more familiar for those who don't like regex.
- Used the `na_values` kwarg to take care of the `"?"` right away in one line.