### PR TITLE
Update `QMOFDataset` docstring

### DIFF
--- a/src/mofdscribe/datasets/qmof_dataset.py
+++ b/src/mofdscribe/datasets/qmof_dataset.py
@@ -14,7 +14,8 @@ from ..constants import MOFDSCRIBE_PYSTOW_MODULE
 
 class QMOFDataset(StructureDataset):
     """
-    Exposes the QMOF dataset by Rosen et al. [Rosen2021a]_ [Rosen2021b]_ .
+    Exposes the QMOF dataset by Rosen et al. [Rosen2021]_ [Rosen2022]_ . Currently
+    based on v14 of the QMOF dataset.
 
     To reduce the risk of data leakage, we (by default) also only keep one representative
     structure for a "base refcode" (i.e. the first five letters of a refcode).
@@ -23,8 +24,8 @@ class QMOFDataset(StructureDataset):
     at different temperatures and hence chemically quite similar.
     For instance, in the QMOF dataset `the basecode BOJKAM appears
     four times
-    <https://next-gen.materialsproject.org/mofs?_sort=data.lcd.value&data__csdRefcode__contains=BOJKAM>`_.
-    Additionally, we  (by default) only keep one structure per "structure hash" which
+    <https://materialsproject.org/mofs?_sort=data.lcd.value&data__csdRefcode__contains=BOJKAM>`_.
+    Additionally, we (by default) only keep one structure per "structure hash" which
     is an approximate graph-isomoprhism check, assuming the VESTA bond thresholds
     for the derivation of the structure graph.
 
@@ -312,7 +313,7 @@ class QMOFDataset(StructureDataset):
     @property
     def citations(self) -> Tuple[str]:
         return [
-            "@article{Rosen2021_a,"
+            "@article{Rosen2021,"
             "doi = {10.1016/j.matt.2021.02.015},"
             "url = {https://doi.org/10.1016/j.matt.2021.02.015},"
             "year = {2021},"
@@ -328,18 +329,13 @@ class QMOFDataset(StructureDataset):
             "metal{\textendash}organic frameworks for accelerated materials discovery},"
             "journal = {Matter}"
             "}",
-            "@article{Rosen2021_b,"
-            "doi = {10.26434/chemrxiv-2021-6cs91},"
-            "url = {https://doi.org/10.26434/chemrxiv-2021-6cs91},"
-            "year = {2021},"
-            "month = dec,"
-            "publisher = {American Chemical Society ({ACS})},"
-            "author = {Andrew S. Rosen and Victor Fung and Patrick Huck and "
-            "Cody T. O{\textquotesingle}Donnell and Matthew K. Horton "
-            "and Donald G. Truhlar and Kristin A. Persson and "
-            "Justin M. Notestein and Randall Q. Snurr},"
-            "title = {High-Throughput Predictions of "
-            "Metal{\textendash}Organic Framework Electronic Properties: "
-            "Theoretical Challenges,  Graph Neural Networks,  and Data Exploration}"
+            "@article{Rosen2022",
+            "title={High-throughput predictions of metal--organic framework electronic properties: theoretical challenges, graph neural networks, and data exploration},"
+            "author={Rosen, Andrew S and Fung, Victor and Huck, Patrick and O’Donnell, Cody T and Horton, Matthew K and Truhlar, Donald G and Persson, Kristin A and Notestein, Justin M and Snurr, Randall Q},"
+            "journal={npj Computational Materials},"
+            "volume={8},"
+            "pages={112},"
+            "year={2022},"
+            "publisher={Nature Publishing Group}"
             "}",
         ]


### PR DESCRIPTION
I clarified some of the `QMOFDataset` docstrings:
- I now specify that the dataset is based on v14 of the QMOF Database.
- I updated the _ChemRxiv_ citation to the current _npj Computational Materials_ citation.
- I changed the next-gen domain in the docstring to the standard materialsproject.org domain name since the former will likely be retired once everything is fully switched over. 

Addressed #308.