### PR TITLE
topology featurizers debug

### DIFF
--- a/src/mofdscribe/featurizers/topology/ph_hist.py
+++ b/src/mofdscribe/featurizers/topology/ph_hist.py
@@ -34,14 +34,14 @@ class PHHist(MOFBaseFeaturizer):
 
     def __init__(
         self,
-        atom_types: Tuple[str] = (
+        atom_types: List[str] = [
             "C-H-N-O",
             "F-Cl-Br-I",
             "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V"
             "-Ag-Nd-U-Ba-Ce-K-Ga-Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-"
             "Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-"
             "Th-Np-Lu-Rh-Pu",
-        ),
+        ],
         compute_for_all_elements: bool = True,
         dimensions: Tuple[int] = (1, 2),
         min_size: int = 20,
@@ -57,12 +57,12 @@ class PHHist(MOFBaseFeaturizer):
         """Initialize the PHStats object.
 
         Args:
-            atom_types (tuple): Atoms that are used to create substructures
+            atom_types (list): Atoms that are used to create substructures
                 for which the persistent homology statistics are computed.
-                Defaults to ( "C-H-N-O", "F-Cl-Br-I",
+                Defaults to [ "C-H-N-O", "F-Cl-Br-I",
                 "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V-Ag-Nd-U-Ba-Ce-K-Ga-
                 Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-
-                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ).
+                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ].
             compute_for_all_elements (bool): Compute descriptor for original structure with all atoms.
                 Defaults to True.
             dimensions (Tuple[int]): Dimensions of topological features to consider.
@@ -89,9 +89,10 @@ class PHHist(MOFBaseFeaturizer):
         """
         atom_types = [] if atom_types is None else atom_types
         self.elements = atom_types
-        self.atom_types = (
-            list(atom_types) + ["all"] if compute_for_all_elements else list(atom_types)
-        )
+        if compute_for_all_elements:
+            self.atom_types = atom_types + ["all"]
+        else:
+            self.atom_types = atom_types
         self.compute_for_all_elements = compute_for_all_elements
         self.dimensions = dimensions
         self.min_size = min_size

--- a/src/mofdscribe/featurizers/topology/ph_image.py
+++ b/src/mofdscribe/featurizers/topology/ph_image.py
@@ -53,14 +53,14 @@ class PHImage(MOFBaseFeaturizer):
 
     def __init__(
         self,
-        atom_types: Optional[Tuple[str]] = (
+        atom_types: Optional[List[str]] = [
             "C-H-N-O",
             "F-Cl-Br-I",
             "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V"
             "-Ag-Nd-U-Ba-Ce-K-Ga-Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-"
             "Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-"
-            "Th-Np-Lu-Rh-Pu",
-        ),
+            "Th-Np-Lu-Rh-Pu"
+        ],
         dimensions: Tuple[int] = (0, 1, 2),
         compute_for_all_elements: bool = True,
         min_size: int = 20,
@@ -78,14 +78,14 @@ class PHImage(MOFBaseFeaturizer):
         """Construct a PHImage object.
 
         Args:
-            atom_types (Tuple[str], optional): Atoms that are used to create
+            atom_types (List[str], optional): Atoms that are used to create
                 substructures that are analysed using persistent homology.
                 If multiple atom types separated by hash are provided, e.g.
                 "C-H-N-O", then the substructure consists of all atoms of type
-                C, H, N, or O. Defaults to ( "C-H-N-O", "F-Cl-Br-I",
+                C, H, N, or O. Defaults to [ "C-H-N-O", "F-Cl-Br-I",
                 "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V-Ag-Nd-U-Ba-
                 Ce-K-Ga-Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-Ho-Re-Be-Rb-La-Sn-Cs-Pb-
-                Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu").
+                Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu"].
             dimensions (Tuple[int]): Dimensions of topological
                 features to consider for persistence images. Defaults to (0, 1, 2).
             compute_for_all_elements (bool): If true, compute
@@ -181,14 +181,14 @@ class PHImage(MOFBaseFeaturizer):
 
     def _get_feature_labels(self) -> List[str]:
         labels = []
-        _elements = list(self.atom_types)
+        _elements = self.atom_types
         if self.compute_for_all_elements:
             _elements.append("all")
-        for element in _elements:
+        for elements_group in _elements:
             for dim in self.dimensions:
                 for pixel_a in range(self.image_size[0]):
                     for pixel_b in range(self.image_size[1]):
-                        labels.append(f"phimage_{element}_{dim}_{pixel_a}_{pixel_b}")
+                        labels.append(f"phimage_{elements_group}_{dim}_{pixel_a}_{pixel_b}")
 
         return labels
 
@@ -293,7 +293,7 @@ class PHImage(MOFBaseFeaturizer):
             alpha_weighting=self.alpha_weight,
         )
         features = []
-        elements = list(self.atom_types)
+        elements = self.atom_types
         if self.compute_for_all_elements:
             elements.append("all")
         for element in elements:

--- a/src/mofdscribe/featurizers/topology/ph_stats.py
+++ b/src/mofdscribe/featurizers/topology/ph_stats.py
@@ -34,14 +34,14 @@ class PHStats(MOFBaseFeaturizer):
 
     def __init__(
         self,
-        atom_types: Tuple[str] = (
+        atom_types: List[str] = [
             "C-H-N-O",
             "F-Cl-Br-I",
             "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V"
             "-Ag-Nd-U-Ba-Ce-K-Ga-Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-"
             "Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-"
             "Th-Np-Lu-Rh-Pu",
-        ),
+        ],
         compute_for_all_elements: bool = True,
         dimensions: Tuple[int] = (1, 2),
         min_size: int = 20,
@@ -54,12 +54,12 @@ class PHStats(MOFBaseFeaturizer):
         """Initialize the PHStats object.
 
         Args:
-            atom_types (tuple): Atoms that are used to create substructures
+            atom_types (list): Atoms that are used to create substructures
                 for which the persistent homology statistics are computed.
-                Defaults to ( "C-H-N-O", "F-Cl-Br-I",
+                Defaults to [ "C-H-N-O", "F-Cl-Br-I",
                 "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V-Ag-Nd-U-Ba-Ce-K-Ga-
                 Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-
-                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ).
+                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ].
             compute_for_all_elements (bool): Compute descriptor for original structure with all atoms.
                 Defaults to True.
             dimensions (Tuple[int]): Dimensions of topological features to consider.
@@ -81,9 +81,10 @@ class PHStats(MOFBaseFeaturizer):
         """
         atom_types = [] if atom_types is None else atom_types
         self.elements = atom_types
-        self.atom_types = (
-            list(atom_types) + ["all"] if compute_for_all_elements else list(atom_types)
-        )
+        if compute_for_all_elements:
+            self.atom_types = atom_types + ["all"]
+        else:
+            self.atom_types = atom_types
         self.compute_for_all_elements = compute_for_all_elements
         self.dimensions = dimensions
         self.min_size = min_size

--- a/src/mofdscribe/featurizers/topology/ph_vect.py
+++ b/src/mofdscribe/featurizers/topology/ph_vect.py
@@ -140,14 +140,14 @@ class PHVect(MOFBaseFeaturizer):
 
     def __init__(
         self,
-        atom_types: Tuple[str] = (
+        atom_types: List[str] = [
             "C-H-N-O",
             "F-Cl-Br-I",
             "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V"
             "-Ag-Nd-U-Ba-Ce-K-Ga-Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-"
             "Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-Hf-Ir-Nb-Pd-Hg-"
             "Th-Np-Lu-Rh-Pu",
-        ),
+        ],
         compute_for_all_elements: bool = True,
         dimensions: Tuple[int] = (1, 2),
         min_size: int = 20,
@@ -165,14 +165,14 @@ class PHVect(MOFBaseFeaturizer):
         """Construct a PHVect instance.
 
         Args:
-            atom_types (tuple): Atoms that are used to create substructures
+            atom_types (list): Atoms that are used to create substructures
                 that are analysed using persistent homology.
                 If multiple atom types separated by hash are provided,
                 e.g. "C-H-N-O", then the substructure consists of all atoms of type C, H, N, or O.
-                Defaults to ( "C-H-N-O", "F-Cl-Br-I",
+                Defaults to [ "C-H-N-O", "F-Cl-Br-I",
                 "Cu-Mn-Ni-Mo-Fe-Pt-Zn-Ca-Er-Au-Cd-Co-Gd-Na-Sm-Eu-Tb-V-Ag-Nd-U-Ba-Ce-K-Ga-
                 Cr-Al-Li-Sc-Ru-In-Mg-Zr-Dy-W-Yb-Y-Ho-Re-Be-Rb-La-Sn-Cs-Pb-Pr-Bi-Tm-Sr-Ti-
-                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ).
+                Hf-Ir-Nb-Pd-Hg-Th-Np-Lu-Rh-Pu", ].
             compute_for_all_elements (bool): If true, compute persistence images
                 for full structure (i.e. with all elements). If false, it will only do it
                 for the substructures specified with `atom_types`. Defaults to True.
@@ -209,9 +209,10 @@ class PHVect(MOFBaseFeaturizer):
         """
         atom_types = [] if atom_types is None else atom_types
         self.elements = atom_types
-        self.atom_types = (
-            list(atom_types) + ["all"] if compute_for_all_elements else list(atom_types)
-        )
+        if compute_for_all_elements:
+            self.atom_types = atom_types + ["all"]
+        else:
+            self.atom_types = atom_types
         self.compute_for_all_elements = compute_for_all_elements
         self.min_size = min_size
         self.dimensions = dimensions

--- a/src/mofdscribe/featurizers/utils/substructures.py
+++ b/src/mofdscribe/featurizers/utils/substructures.py
@@ -35,6 +35,39 @@ def filter_element(
         return Structure.from_sites(keep_sites)
     else:  # input is molecule or IMolecule
         return Molecule.from_sites(keep_sites)
+    
+
+def filter_element_for_ph(
+    structure: Union[Structure, IStructure, Molecule, IMolecule], elements: str
+) -> Structure:
+    """Filter a structure by element.
+
+    Args:
+        structure (Union[Structure, IStructure, Molecule, IMolecule]): input structure
+        elements (str): element to filter
+
+    Returns:
+        filtered_structure (Structure): filtered structure
+    """
+    elements_ = []
+    elements_group = (elements,)
+    for atom_type in elements_group:
+        if "-" in atom_type:
+            elements_.extend(atom_type.split("-"))
+        else:
+            elements_.append(atom_type)
+    keep_sites = []
+    for site in structure.sites:
+        if site.specie.symbol in elements_:
+            keep_sites.append(site)
+    if len(keep_sites) == 0:
+        return None
+
+    input_is_structure = isinstance(structure, (Structure, IStructure))
+    if input_is_structure:
+        return Structure.from_sites(keep_sites)
+    else:  # input is molecule or IMolecule
+        return Molecule.from_sites(keep_sites)
 
 
 def elements_in_structure(structure: Structure) -> List[str]:


### PR DESCRIPTION
Hi, I found a bug in the topology featurizers. The original way of splitting `atom_types` will split `'Cu'` to `['C', 'u']`, for example. Besides, the `tuple` type is error-prone to the last `,` as highlighted by the red circle in the figure attached. 

Thus, I made several changes accordingly:

-  change the data type of `atom_types` from `tuple` to `list`;
-  add a function `filter_element_for_ph`, which is a modified version of `filter_element` for persistence homology. This function is added instead of modifying the original function because `filter_element` is also called by `mofdscribe.featurizers.chemistry.AMD`
- uncomment the two lines: https://github.com/kjappelbaum/mofdscribe/blob/44c44f7b9d847105073432b4fb66ad750e6e63b2/src/mofdscribe/featurizers/topology/_tda_helpers.py#L107 and https://github.com/kjappelbaum/mofdscribe/blob/44c44f7b9d847105073432b4fb66ad750e6e63b2/src/mofdscribe/featurizers/topology/_tda_helpers.py#L108

 
![Thermal conductivity](https://github.com/user-attachments/assets/24a0d77d-bcf4-4df5-bceb-a1f06dfd5490)
