### PR TITLE
fix: unit correction

### DIFF
--- a/src/mofdscribe/featurizers/pore/geometric_properties.py
+++ b/src/mofdscribe/featurizers/pore/geometric_properties.py
@@ -362,7 +362,7 @@ class AccessibleVolume(MOFBaseFeaturizer):
         labels = [
             "uc_volume",
             "density",
-            "av_a2",
+            "av_a3",
             "av_volume_fraction",
             "av_cm3g",
             "nav_a3",

--- a/tests/featurizers/pore/test_geometric_properties.py
+++ b/tests/featurizers/pore/test_geometric_properties.py
@@ -119,7 +119,7 @@ def test_accessible_volume(hkust_structure):
     expected_labels = [
         "uc_volume",
         "density",
-        "av_a2",
+        "av_a3",
         "av_volume_fraction",
         "av_cm3g",
         "nav_a3",


### PR DESCRIPTION
av_a2 -> av_a3

I changed av_a2 everywhere

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the unit label from 'av_a2' to 'av_a3' in the geometric properties featurizer and update corresponding tests to ensure consistency.

Bug Fixes:
- Correct the unit label from 'av_a2' to 'av_a3' in the geometric properties featurizer.

Tests:
- Update test expectations to reflect the corrected unit label from 'av_a2' to 'av_a3'.

<!-- Generated by sourcery-ai[bot]: end summary -->